### PR TITLE
fix: failed to load assets on github-pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,18 +30,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
-      - name: Fix public asset paths
-        run: |
-          find src -type f \( -name "*.tsx" -o -name "*.ts" \) | xargs sed -i \
-            -e 's|src="/icons/|src="/mirabile/icons/|g' \
-            -e 's|src="icons/|src="/mirabile/icons/|g' \
-            -e 's|src="/images/|src="/mirabile/images/|g' \
-            -e 's|src="images/|src="/mirabile/images/|g' \
-            -e 's|src="/logo.png"|src="/mirabile/logo.png"|g' \
-            -e 's|src="logo.png"|src="/mirabile/logo.png"|g' \
-            -e 's|src="/background.png"|src="/mirabile/background.png"|g' \
-            -e 's|src="background.png"|src="/mirabile/background.png"|g' \
-            -e 's|src="/favicon.png"|src="/mirabile/favicon.png"|g'
+
 
       - name: Build
         run: pnpm exec vite build

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.png" />
+    <link rel="icon" type="image/png" href="/images/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Career Roadmap AI</title>
     <script src="https://js.puter.com/v2/"></script>

--- a/src/components/home/CompanyMarquee.tsx
+++ b/src/components/home/CompanyMarquee.tsx
@@ -1,4 +1,5 @@
 import { useState, MouseEvent } from "react";
+import { assetUrl } from '@/lib/assetUrl';
 
 type Company = {
   name: string,
@@ -7,18 +8,18 @@ type Company = {
 }
 
 const COMPANIES: Company[] = [
-  { name: 'Google',    icon: '/icons/google.png',    color: '#4285F4' },
-  { name: 'Meta',      icon: '/icons/meta.png',      color: '#0082FB' },
-  { name: 'Amazon',    icon: '/icons/amazon.png',    color: '#FF9900' },
-  { name: 'Microsoft', icon: '/icons/microsoft.png', color: '#00A4EF' },
-  { name: 'Apple',     icon: '/icons/apple.png',     color: '#A2AAAD' },
-  { name: 'Stripe',    icon: '/icons/stripe.png',    color: '#635BFF' },
-  { name: 'Adobe',     icon: '/icons/adobe.png',     color: '#EE1515' },
-  { name: 'LinkedIn',  icon: '/icons/linkedin.png',  color: '#0A66C2' },
-  { name: 'NVIDIA',    icon: '/icons/nvidia.png',    color: '#76B900' },
-  { name: 'IBM',       icon: '/icons/ibm.png',       color: '#8C8686' },
-  { name: 'OpenAI',    icon: '/icons/openai.png',    color: '#AAAAAA' },
-  { name: 'Pinterest', icon: '/icons/pinterest.png', color: '#E60023' },
+  { name: 'Google',    icon: assetUrl('icons/google.png'),    color: '#4285F4' },
+  { name: 'Meta',      icon: assetUrl('icons/meta.png'),      color: '#0082FB' },
+  { name: 'Amazon',    icon: assetUrl('icons/amazon.png'),    color: '#FF9900' },
+  { name: 'Microsoft', icon: assetUrl('icons/microsoft.png'), color: '#00A4EF' },
+  { name: 'Apple',     icon: assetUrl('icons/apple.png'),     color: '#A2AAAD' },
+  { name: 'Stripe',    icon: assetUrl('icons/stripe.png'),    color: '#635BFF' },
+  { name: 'Adobe',     icon: assetUrl('icons/adobe.png'),     color: '#EE1515' },
+  { name: 'LinkedIn',  icon: assetUrl('icons/linkedin.png'),  color: '#0A66C2' },
+  { name: 'NVIDIA',    icon: assetUrl('icons/nvidia.png'),    color: '#76B900' },
+  { name: 'IBM',       icon: assetUrl('icons/ibm.png'),       color: '#8C8686' },
+  { name: 'OpenAI',    icon: assetUrl('icons/openai.png'),    color: '#AAAAAA' },
+  { name: 'Pinterest', icon: assetUrl('icons/pinterest.png'), color: '#E60023' },
 ];
 
 const TRACK = [...COMPANIES, ...COMPANIES];

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { assetUrl } from '@/lib/assetUrl';
 import { ArrowRight, LayoutDashboard, Map } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { ReactiveOrb } from '@/components/home/Interactiveorb';
@@ -63,7 +64,7 @@ export function HeroSection() {
 
             {/* Brand pill */}
             <div className="hf1 flex items-center gap-3">
-              <img src="/images/logo.png" alt="Mirabile" className="h-20 w-20 object-contain" />
+              <img src={assetUrl('images/logo.png')} alt="Mirabile" className="h-20 w-20 object-contain" />
             </div>
 
             {/* Headline */}

--- a/src/components/layouts/Navbar.tsx
+++ b/src/components/layouts/Navbar.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { assetUrl } from '@/lib/assetUrl';
 import { Link, useLocation, useNavigate } from 'react-router';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -88,7 +89,7 @@ function LogoLink() {
   return (
     <Link to="/" className="relative overflow-hidden flex items-center gap-2.5">
       {glow}
-      <img src="/images/logo.png" className="h-8" alt="logo" />
+      <img src={assetUrl('images/logo.png')} className="h-8" alt="logo" />
       <span className="text-xl font-bold text-white">
         Mirabile
       </span>

--- a/src/lib/assetUrl.ts
+++ b/src/lib/assetUrl.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolves a public-folder asset path using Vite's configured base URL.
+ *
+ * In development  → import.meta.env.BASE_URL is "/"
+ * In production   → import.meta.env.BASE_URL is "/mirabile/" (from vite.config.ts)
+ *
+ * Usage:
+ *   assetUrl('images/logo.png')        → "/images/logo.png"  (dev)
+ *                                       → "/mirabile/images/logo.png"  (prod)
+ *   assetUrl('icons/google.png')       → "/icons/google.png"  (dev)
+ *                                       → "/mirabile/icons/google.png"  (prod)
+ */
+export function assetUrl(path: string): string {
+  const base = import.meta.env.BASE_URL ?? '/';
+  // Strip leading slash from path to avoid double slashes
+  return `${base}${path.replace(/^\//, '')}`;
+}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { assetUrl } from '@/lib/assetUrl';
 import ReactMarkdown from 'react-markdown';
 import { useParams, useNavigate } from 'react-router';
 import type { Components } from 'react-markdown';
@@ -175,7 +176,7 @@ Assistant:`;
           {messages.length === 0 && (
             <div className="flex flex-col items-center justify-center py-20 text-center space-y-4">
               <div className="h-20 w-20 flex items-center justify-center mb-4">
-                <img src="/images/logo.png" className="w-full h-full object-contain" alt="AI" />
+                <img src={assetUrl('images/logo.png')} className="w-full h-full object-contain" alt="AI" />
               </div>
               <h2 className="text-2xl font-bold text-white">Hello! I'm your career assistant.</h2>
               <p className="text-white/70 max-w-sm">
@@ -212,7 +213,7 @@ Assistant:`;
                   </>
                 ) : (
                   <>
-                    <AvatarImage src="/images/logo.png" className="object-contain" />
+                    <AvatarImage src={assetUrl('images/logo.png')} className="object-contain" />
                     <AvatarFallback className="bg-transparent">
                       <Bot className="h-5 w-5 text-[#0AFFE4]" />
                     </AvatarFallback>
@@ -249,7 +250,7 @@ Assistant:`;
           {isLoading && (
             <div className="flex gap-3">
               <Avatar className="h-10 w-10 shrink-0">
-                <AvatarImage src="/images/logo.png" className="object-contain" />
+                <AvatarImage src={assetUrl('images/logo.png')} className="object-contain" />
                 <AvatarFallback className="bg-transparent">
                   <Bot className="h-5 w-5 text-[#0AFFE4]" />
                 </AvatarFallback>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -21,25 +21,26 @@ import type { Roadmap } from '@/types';
 import { LineChart, Line, AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import { Google, Meta, Apple, Microsoft, Amazon, Netflix, Nvidia, Oracle, Tesla, Adobe, Salesforce } from '@/assets/images/cards';
 import { getBrandColors } from '../constants/companyBranding.ts';
+import { assetUrl } from '@/lib/assetUrl';
 
 const COMPANY_CONFIG: Record<string, { color: string, logoUrl: string, coverUrl: string }> = {
-  'Google': { color: getBrandColors('Google').primary, logoUrl: '/icons/google.png', coverUrl: Google },
-  'Meta': { color: getBrandColors('Meta').primary, logoUrl: '/icons/meta.png', coverUrl: Meta },
-  'Apple': { color: getBrandColors('Apple').primary, logoUrl: '/icons/apple.png', coverUrl: Apple },
-  'Microsoft': { color: getBrandColors('Microsoft').primary, logoUrl: '/icons/microsoft.png', coverUrl: Microsoft },
-  'Amazon': { color: getBrandColors('Amazon').primary, logoUrl: '/icons/amazon.png', coverUrl: Amazon },
-  'Netflix': { color: getBrandColors('Netflix').primary, logoUrl: '/icons/netflix.png', coverUrl: Netflix },
-  'Nvidia': { color: getBrandColors('Nvidia').primary, logoUrl: '/icons/nvidia.png', coverUrl: Nvidia },
-  'Oracle': { color: getBrandColors('Oracle').primary, logoUrl: '/icons/oracle.png', coverUrl: Oracle },
-  'Tesla': { color: getBrandColors('Tesla').primary, logoUrl: '/icons/tesla.png', coverUrl: Tesla },
-  'Adobe': { color: getBrandColors('Adobe').primary, logoUrl: '/icons/adobe.png', coverUrl: Adobe },
-  'Salesforce': { color: getBrandColors('Salesforce').primary, logoUrl: '/icons/salesforce.png', coverUrl: Salesforce },
+  'Google':     { color: getBrandColors('Google').primary,     logoUrl: assetUrl('icons/google.png'),     coverUrl: Google },
+  'Meta':       { color: getBrandColors('Meta').primary,       logoUrl: assetUrl('icons/meta.png'),       coverUrl: Meta },
+  'Apple':      { color: getBrandColors('Apple').primary,      logoUrl: assetUrl('icons/apple.png'),      coverUrl: Apple },
+  'Microsoft':  { color: getBrandColors('Microsoft').primary,  logoUrl: assetUrl('icons/microsoft.png'),  coverUrl: Microsoft },
+  'Amazon':     { color: getBrandColors('Amazon').primary,     logoUrl: assetUrl('icons/amazon.png'),     coverUrl: Amazon },
+  'Netflix':    { color: getBrandColors('Netflix').primary,    logoUrl: assetUrl('icons/netflix.png'),    coverUrl: Netflix },
+  'Nvidia':     { color: getBrandColors('Nvidia').primary,     logoUrl: assetUrl('icons/nvidia.png'),     coverUrl: Nvidia },
+  'Oracle':     { color: getBrandColors('Oracle').primary,     logoUrl: assetUrl('icons/oracle.png'),     coverUrl: Oracle },
+  'Tesla':      { color: getBrandColors('Tesla').primary,      logoUrl: assetUrl('icons/tesla.png'),      coverUrl: Tesla },
+  'Adobe':      { color: getBrandColors('Adobe').primary,      logoUrl: assetUrl('icons/adobe.png'),      coverUrl: Adobe },
+  'Salesforce': { color: getBrandColors('Salesforce').primary, logoUrl: assetUrl('icons/salesforce.png'), coverUrl: Salesforce },
 };
 
 const getCompanyConfig = (name: string) => {
   const key = Object.keys(COMPANY_CONFIG).find(k => name.toLowerCase().includes(k.toLowerCase()));
   if (key) return COMPANY_CONFIG[key];
-  return { color: '#0AFFE4', logoUrl: '/icons/adobe.png', coverUrl: '/src/assets/images/cards/Google.jpg' };
+  return { color: '#0AFFE4', logoUrl: assetUrl('icons/adobe.png'), coverUrl: Google };
 };
 
 const daily = 24 * 60 * 60 * 1000;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { assetUrl } from '@/lib/assetUrl';
 import { useNavigate, Link } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -108,7 +109,7 @@ export default function LoginPage() {
     <div
       className="relative flex min-h-screen w-full items-center justify-center overflow-hidden p-4"
       style={{
-        backgroundImage: 'url(/images/background.png)',
+        backgroundImage: `url(${assetUrl('images/background.png')})`,
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         backgroundAttachment: 'fixed',
@@ -140,7 +141,7 @@ export default function LoginPage() {
         <CardHeader className="relative z-10 space-y-1 pb-4">
           <div className="mb-3 flex justify-center">
             <img
-              src="/images/logo.png"
+              src={assetUrl('images/logo.png')}
               alt="Mirabile"
               className="h-12 drop-shadow-[0_0_15px_rgba(255,255,255,0.35)]"
             />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { assetUrl } from '@/lib/assetUrl';
 import PageMeta from "@/components/common/PageMeta";
 
 export default function NotFound() {
@@ -11,9 +12,9 @@ export default function NotFound() {
             ERROR
           </h1>
 
-          <img src="/images/error/404.svg" alt="404" className="dark:hidden" />
+          <img src={assetUrl('images/error/404.svg')} alt="404" className="dark:hidden" />
           <img
-            src="/images/error/404-dark.svg"
+            src={assetUrl('images/error/404-dark.svg')}
             alt="404"
             className="hidden dark:block"
           />

--- a/src/pages/ProgressTrackingPage.tsx
+++ b/src/pages/ProgressTrackingPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
+import { assetUrl } from '@/lib/assetUrl';
 import { format, subDays, eachDayOfInterval } from 'date-fns';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -228,7 +229,7 @@ function CompanyIcon({ company, color }: { company: string; color: string }) {
   }
   return (
     <img
-      src={`/icons/${company.toLowerCase().replace(/\s+/g, '')}.png`}
+      src={assetUrl(`icons/${company.toLowerCase().replace(/\s+/g, '')}.png`)}
       alt={company}
       className="w-10 h-10 rounded-lg object-contain bg-white/5 p-1 shrink-0"
       onError={() => setError(true)}

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { assetUrl } from '@/lib/assetUrl';
 import { useNavigate, Link } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -72,7 +73,7 @@ export default function RegisterPage() {
     <div
       className="relative flex min-h-screen w-full items-center justify-center overflow-hidden p-4"
       style={{
-        backgroundImage: 'url(/images/background.png)',
+        backgroundImage: `url(${assetUrl('images/background.png')})`,
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         backgroundAttachment: 'fixed',
@@ -104,7 +105,7 @@ export default function RegisterPage() {
         <CardHeader className="relative z-10 space-y-1 pb-4">
           <div className="mb-3 flex justify-center">
             <img
-              src="/images/logo.png"
+              src={assetUrl('images/logo.png')}
               alt="Mirabile"
               className="h-12 drop-shadow-[0_0_15px_rgba(255,255,255,0.35)]"
             />

--- a/src/pages/RoadmapViewerPage.tsx
+++ b/src/pages/RoadmapViewerPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { assetUrl } from '@/lib/assetUrl';
 import { useParams } from 'react-router';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -15,23 +16,23 @@ import { getHiringStat } from '@/constants/companyHiringStats';
 
 /* ── Company icon from /public/icons/ ── */
 const COMPANY_ICONS: Record<string, string> = {
-  google: '/icons/google.png',
-  microsoft: '/icons/microsoft.png',
-  meta: '/icons/meta.png',
-  amazon: '/icons/amazon.png',
-  apple: '/icons/apple.png',
-  nvidia: '/icons/nvidia.png',
-  adobe: '/icons/adobe.png',
-  ibm: '/icons/ibm.png',
-  linkedin: '/icons/linkedin.png',
-  openai: '/icons/openai.png',
-  pinterest: '/icons/pinterest.png',
-  stripe: '/icons/stripe.png',
+  google:    assetUrl('icons/google.png'),
+  microsoft: assetUrl('icons/microsoft.png'),
+  meta:      assetUrl('icons/meta.png'),
+  amazon:    assetUrl('icons/amazon.png'),
+  apple:     assetUrl('icons/apple.png'),
+  nvidia:    assetUrl('icons/nvidia.png'),
+  adobe:     assetUrl('icons/adobe.png'),
+  ibm:       assetUrl('icons/ibm.png'),
+  linkedin:  assetUrl('icons/linkedin.png'),
+  openai:    assetUrl('icons/openai.png'),
+  pinterest: assetUrl('icons/pinterest.png'),
+  stripe:    assetUrl('icons/stripe.png'),
 };
 
 function getCompanyIcon(companyName: string): string {
   const id = companyName.toLowerCase().replace(/\s+/g, '');
-  return COMPANY_ICONS[id] ?? `/icons/${id}.png`;
+  return COMPANY_ICONS[id] ?? assetUrl(`icons/${id}.png`);
 }
 
 /* ── Phase config: color + icon ── */


### PR DESCRIPTION
## Summary of All Issues

| # | Issue | Files Affected | Fix |
|---|-------|---------------|-----|
| 1 | `/images/` paths in JSX `src=` and CSS-in-JS | `LoginPage`, `RegisterPage`, `ChatPage`, `Navbar`, `HeroSection` | Import images as ES modules, use `import.meta.env.BASE_URL` |
| 2 | `/icons/` paths in JS objects | `RoadmapViewerPage`, `DashboardPage`, `CompanyMarquee`, `ProgressTrackingPage` | Use `import.meta.env.BASE_URL` prefix |
| 3 | `/src/assets/` hardcoded path | `DashboardPage` fallback | Import image as ES module |
| 4 | `sed`-based CI workaround is incomplete | `deploy.yml` | Remove `sed` hack; fix source files properly |
| 5 | `favicon.png` doesn't exist in `public/` | `index.html` | Move/rename or create favicon |
| 6 | `/images/error/404.svg` files missing | `NotFound.tsx` | Add files or use different images |